### PR TITLE
fix(dolares): corregir cotización histórica bolsa y CCL 2025-05-02..04 (#18)

### DIFF
--- a/datos/v1/cotizaciones/dolares/2025/05/02/index.json
+++ b/datos/v1/cotizaciones/dolares/2025/05/02/index.json
@@ -13,14 +13,14 @@
   },
   {
     "casa": "bolsa",
-    "compra": 751.67,
-    "venta": 1363.6,
+    "compra": 1177.7,
+    "venta": 1182.8,
     "fecha": "2025-05-02"
   },
   {
     "casa": "contadoconliqui",
-    "compra": 1382.9,
-    "venta": 1429.3,
+    "compra": 1187.9,
+    "venta": 1190.6,
     "fecha": "2025-05-02"
   },
   {

--- a/datos/v1/cotizaciones/dolares/2025/05/03/index.json
+++ b/datos/v1/cotizaciones/dolares/2025/05/03/index.json
@@ -13,14 +13,14 @@
   },
   {
     "casa": "bolsa",
-    "compra": 1193.9,
-    "venta": 1170.4,
+    "compra": 1177.7,
+    "venta": 1182.8,
     "fecha": "2025-05-03"
   },
   {
     "casa": "contadoconliqui",
-    "compra": 1382.9,
-    "venta": 1429.3,
+    "compra": 1187.9,
+    "venta": 1190.6,
     "fecha": "2025-05-03"
   },
   {

--- a/datos/v1/cotizaciones/dolares/2025/05/04/index.json
+++ b/datos/v1/cotizaciones/dolares/2025/05/04/index.json
@@ -13,14 +13,14 @@
   },
   {
     "casa": "bolsa",
-    "compra": 1193.9,
-    "venta": 1170.4,
+    "compra": 1177.7,
+    "venta": 1182.8,
     "fecha": "2025-05-04"
   },
   {
     "casa": "contadoconliqui",
-    "compra": 1382.9,
-    "venta": 1429.3,
+    "compra": 1187.9,
+    "venta": 1190.6,
     "fecha": "2025-05-04"
   },
   {

--- a/datos/v1/cotizaciones/dolares/bolsa/2025/05/02/index.json
+++ b/datos/v1/cotizaciones/dolares/bolsa/2025/05/02/index.json
@@ -1,6 +1,6 @@
 {
   "casa": "bolsa",
-  "compra": 751.67,
-  "venta": 1363.6,
+  "compra": 1177.7,
+  "venta": 1182.8,
   "fecha": "2025-05-02"
 }

--- a/datos/v1/cotizaciones/dolares/bolsa/2025/05/03/index.json
+++ b/datos/v1/cotizaciones/dolares/bolsa/2025/05/03/index.json
@@ -1,6 +1,6 @@
 {
   "casa": "bolsa",
-  "compra": 1193.9,
-  "venta": 1170.4,
+  "compra": 1177.7,
+  "venta": 1182.8,
   "fecha": "2025-05-03"
 }

--- a/datos/v1/cotizaciones/dolares/bolsa/2025/05/04/index.json
+++ b/datos/v1/cotizaciones/dolares/bolsa/2025/05/04/index.json
@@ -1,6 +1,6 @@
 {
   "casa": "bolsa",
-  "compra": 1193.9,
-  "venta": 1170.4,
+  "compra": 1177.7,
+  "venta": 1182.8,
   "fecha": "2025-05-04"
 }

--- a/datos/v1/cotizaciones/dolares/bolsa/index.json
+++ b/datos/v1/cotizaciones/dolares/bolsa/index.json
@@ -14263,20 +14263,20 @@
   },
   {
     "casa": "bolsa",
-    "compra": 751.67,
-    "venta": 1363.6,
+    "compra": 1177.7,
+    "venta": 1182.8,
     "fecha": "2025-05-02"
   },
   {
     "casa": "bolsa",
-    "compra": 1193.9,
-    "venta": 1170.4,
+    "compra": 1177.7,
+    "venta": 1182.8,
     "fecha": "2025-05-03"
   },
   {
     "casa": "bolsa",
-    "compra": 1193.9,
-    "venta": 1170.4,
+    "compra": 1177.7,
+    "venta": 1182.8,
     "fecha": "2025-05-04"
   },
   {

--- a/datos/v1/cotizaciones/dolares/contadoconliqui/2025/05/02/index.json
+++ b/datos/v1/cotizaciones/dolares/contadoconliqui/2025/05/02/index.json
@@ -1,6 +1,6 @@
 {
   "casa": "contadoconliqui",
-  "compra": 1382.9,
-  "venta": 1429.3,
+  "compra": 1187.9,
+  "venta": 1190.6,
   "fecha": "2025-05-02"
 }

--- a/datos/v1/cotizaciones/dolares/contadoconliqui/2025/05/03/index.json
+++ b/datos/v1/cotizaciones/dolares/contadoconliqui/2025/05/03/index.json
@@ -1,6 +1,6 @@
 {
   "casa": "contadoconliqui",
-  "compra": 1382.9,
-  "venta": 1429.3,
+  "compra": 1187.9,
+  "venta": 1190.6,
   "fecha": "2025-05-03"
 }

--- a/datos/v1/cotizaciones/dolares/contadoconliqui/2025/05/04/index.json
+++ b/datos/v1/cotizaciones/dolares/contadoconliqui/2025/05/04/index.json
@@ -1,6 +1,6 @@
 {
   "casa": "contadoconliqui",
-  "compra": 1382.9,
-  "venta": 1429.3,
+  "compra": 1187.9,
+  "venta": 1190.6,
   "fecha": "2025-05-04"
 }

--- a/datos/v1/cotizaciones/dolares/contadoconliqui/index.json
+++ b/datos/v1/cotizaciones/dolares/contadoconliqui/index.json
@@ -27019,20 +27019,20 @@
   },
   {
     "casa": "contadoconliqui",
-    "compra": 1382.9,
-    "venta": 1429.3,
+    "compra": 1187.9,
+    "venta": 1190.6,
     "fecha": "2025-05-02"
   },
   {
     "casa": "contadoconliqui",
-    "compra": 1382.9,
-    "venta": 1429.3,
+    "compra": 1187.9,
+    "venta": 1190.6,
     "fecha": "2025-05-03"
   },
   {
     "casa": "contadoconliqui",
-    "compra": 1382.9,
-    "venta": 1429.3,
+    "compra": 1187.9,
+    "venta": 1190.6,
     "fecha": "2025-05-04"
   },
   {

--- a/datos/v1/cotizaciones/dolares/index.json
+++ b/datos/v1/cotizaciones/dolares/index.json
@@ -160765,14 +160765,14 @@
   },
   {
     "casa": "bolsa",
-    "compra": 751.67,
-    "venta": 1363.6,
+    "compra": 1177.7,
+    "venta": 1182.8,
     "fecha": "2025-05-02"
   },
   {
     "casa": "contadoconliqui",
-    "compra": 1382.9,
-    "venta": 1429.3,
+    "compra": 1187.9,
+    "venta": 1190.6,
     "fecha": "2025-05-02"
   },
   {
@@ -160807,14 +160807,14 @@
   },
   {
     "casa": "bolsa",
-    "compra": 1193.9,
-    "venta": 1170.4,
+    "compra": 1177.7,
+    "venta": 1182.8,
     "fecha": "2025-05-03"
   },
   {
     "casa": "contadoconliqui",
-    "compra": 1382.9,
-    "venta": 1429.3,
+    "compra": 1187.9,
+    "venta": 1190.6,
     "fecha": "2025-05-03"
   },
   {
@@ -160849,14 +160849,14 @@
   },
   {
     "casa": "bolsa",
-    "compra": 1193.9,
-    "venta": 1170.4,
+    "compra": 1177.7,
+    "venta": 1182.8,
     "fecha": "2025-05-04"
   },
   {
     "casa": "contadoconliqui",
-    "compra": 1382.9,
-    "venta": 1429.3,
+    "compra": 1187.9,
+    "venta": 1190.6,
     "fecha": "2025-05-04"
   },
   {


### PR DESCRIPTION
Corrige los valores erróneos reportados en #18 para el fin de semana largo del 1 al 4 de mayo de 2025.

**Qué se corrige**
1. `datos/v1/cotizaciones/dolares/bolsa/2025/05/02` — 751.67/1363.6 → 1177.70/1182.80
2. `bolsa/2025/05/03` y `04` — 1193.9/1170.4 (invertido) → 1177.70/1182.80
3. `contadoconliqui/2025/05/02..04` — 1382.9/1429.3 → 1187.90/1190.60
4. Los mismos 6 registros en `datos/v1/cotizaciones/dolares/index.json`, `bolsa/index.json`, `contadoconliqui/index.json` y los agregados por fecha `2025/05/02..04/index.json`.

El 2025-05-01 es feriado y el 02 es día no laborable con fin turístico (ver `datos/v1/feriados-bancarios/2025`). El oficial ya estaba plano en 1140/1190; bolsa y CCL deben quedar igual que el último día hábil 2025-04-30. Cripto no se toca porque opera 24/7.

**Resultado visible**
La API ` /v1/cotizaciones/dolares` ya no devuelve picos ni valores invertidos para esos tres días. Un consumidor que grafique MEP/CCL ve línea plana del 30/04 al 04/05 y retoma el 05/05 en 1200/1205.2 y 1208.6/1212.6.

**Validación**
```
node verify_fix.mjs
✅ ALL CHECKS PASSED — bug fixed, no inverted values

# sabotage check
# revertir bolsa/2025/05/02 a 751.67/1363.6 → verify falla (1 check failed)
# restaurar → verify pasa de nuevo
```
Integridad: `pnpm test tests/cotizaciones/integridad/comprobarDolares.test.js` — dos tests ya fallaban en main (orden y timeout) antes del cambio; no hay regresión nueva. La verificación de que no haya días faltantes sigue pasando.

**Diff**
12 archivos, 48 inserciones / 48 eliminaciones. Solo valores compra/venta de los dos casas en las tres fechas, sin reordenar ni formatear.

Fixes #18


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correcciones**
  - Actualizadas las cotizaciones del dólar para los días 2, 3 y 4 de mayo de 2025.
  - Corregidos los valores de compra y venta del dólar bolsa: 1177,7 y 1182,8.
  - Corregidos los valores del dólar contado con liquidación: 1187,9 y 1190,6.
  - Sin cambios en el resto de las cotizaciones ni en la estructura de los datos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->